### PR TITLE
Change handling of environment variables

### DIFF
--- a/borgcron.sh
+++ b/borgcron.sh
@@ -89,22 +89,15 @@ fi
 
 # check that variables are set
 if [ "$BACKUP_NAME" = "" ] ||
-   [ "$REPOSITORY" = "" ] ||
+   [ "$BORG_REPO" = "" ] ||
    [ "$ARCHIVE_NAME" = "" ] ||
    [ "$BACKUP_DIRS" = "" ]; then
 	echo 'Some required variables may not be set in the config file. Cancel backup.'
 	exit 1
 fi
-
-# export borg repo variable
-export BORG_REPO="$REPOSITORY"
-
-# get passphrase
-if [ -f "$PASSPHRASE_FILE" ]; then
-	export BORG_PASSPHRASE
-	BORG_PASSPHRASE=$( cat "$PASSPHRASE_FILE" )
-else
-	info_log "No (valid) passphrase file given."
+if ! export|grep "BORG_REPO"; then
+	echo 'The BORG_REPO variable is not exported in the config file. Cancel backup.'
+	exit 1
 fi
 
 # log

--- a/config/example-backup.sh
+++ b/config/example-backup.sh
@@ -3,23 +3,34 @@
 
 # basic, required information
 BACKUP_NAME='example-backup' # name for this backup avoid spaces
-REPOSITORY='ssh://user@somewhere.example:22/./dir'
+export BORG_REPO='ssh://user@somewhere.example:22/./dir'
 ARCHIVE_NAME="{hostname}-$BACKUP_NAME-{now:%Y-%m-%dT%H:%M:%S}" # or %Y-%m-%d
 BACKUP_DIRS="/home /etc /srv /var/log /var/mail /var/lib /var/spool /opt /root /usr/local" # path to be backed up, without spaces
 
 # additional backup options
-PASSPHRASE_FILE="somewhere/example-key" # the passphrase file, if your repo is encrypted
+export BORG_PASSCOMMAND='cat "path/to/example-key"' # command to get passphrase (requires borg v1.1.0 or higher)
+# export BORG_PASSPHRASE="1234" # or enter the passphrase directly
 COMPRESSION="lz4" # lz4 | zlib,6 | lzma,9
 
 PRUNE_PARAMS="--keep-daily=14 --keep-weekly=8 --keep-monthly=6 --keep-yearly=0"
-# for web servers (only disaster recovery:) --keep-daily=7 --keep-weekly=4 --keep-monthly=1 --keep-yearly=0
+# for web servers (only disaster recovery): --keep-daily=7 --keep-weekly=4 --keep-monthly=1 --keep-yearly=0
 
 # additional settings
 ADD_BACKUP_PARAMS="" # --one-file-system for backing up root file dir
 SLEEP_TIME="5m" # time, the script should wait until re-attempting the backup after a failed try
 REPEAT_NUM="3" # = three retries after accepting a failed backup
 
-# create installed list
+# borg-internal settings
+# (see https://borgbackup.readthedocs.io/en/stable/usage.html#environment-variables)
+# export BORG_RSH="ssh -i /path/to/private.key"
+# export BORG_REMOTE_PATH="/path/to/special/borg"
+
+# export TMPDIR="/tmp"
+# export BORG_KEYS_DIR="~/.config/borg/keys"
+# export BORG_SECURITY_DIR="~/.config/borg/security"
+# export BORG_CACHE_DIR="~/.cache/borg"
+
+# create list of installed packages
 #
 # RPM-based:
 # dnf list installed > "$BASE_DIR/backup/dnf.list" 2>/dev/null


### PR DESCRIPTION
* Now more defined in config file and exported there. No useless passing to
  helper and exporting later. Fixes https://github.com/rugk/borg-cron-helper/issues/8
* BORG_PASSCOMMAND, Fixes https://github.com/rugk/borg-cron-helper/issues/4
* add other common env. vars