### PR TITLE
Change REPEAT_NUM to RETRY_NUM

### DIFF
--- a/borgcron.sh
+++ b/borgcron.sh
@@ -18,7 +18,7 @@ RUN_PID_DIR="/var/run/borg"
 COMPRESSION="lz4"
 ADD_BACKUP_PARAMS=""
 SLEEP_TIME="5m"
-REPEAT_NUM="3"
+RETRY_NUM="3"
 
 # set placeholder/default value
 PRUNE_PREFIX="null"
@@ -167,10 +167,7 @@ echo
 info_log "Backup $BACKUP_NAME started with $( $BORG_BIN -V ), PID: $$."
 guiShowBackupBegin
 
-# when 0 is given, this does not mean "don't execute backup", but "do not retry".
-[ $REPEAT_NUM -le 1 ] && REPEAT_NUM=1
-
-for i in $( seq "$REPEAT_NUM" ); do
+for i in $( seq "$(( RETRY_NUM+1 ))" ); do
 	if is_lock; then
 		error_log "Backup $BACKUP_NAME is locked. Cancel."
 		exit 1
@@ -204,7 +201,7 @@ for i in $( seq "$REPEAT_NUM" ); do
 			error_log "Borg exited with fatal error." #(2)
 
 			# ignore last try
-			if [ "$i" -lt "$REPEAT_NUM" ]; then
+			if [ "$i" -lt "$RETRY_NUM" ]; then
 				# wait some time to recover from the error
 				info_log "Wait $SLEEP_TIME…"
 				sleep "$SLEEP_TIME"

--- a/config/example-backup.sh
+++ b/config/example-backup.sh
@@ -26,7 +26,7 @@ PRUNE_PARAMS="--keep-daily=14 --keep-weekly=8 --keep-monthly=6 --keep-yearly=0"
 # additional settings
 ADD_BACKUP_PARAMS="" # --one-file-system for backing up root file dir
 SLEEP_TIME="5m" # time, the script should wait until re-attempting the backup after a failed try
-REPEAT_NUM="3" # = three retries after accepting a failed backup
+RETRY_NUM="3" # = retry after a failed backup for n number of times
 
 # GUI settings
 GUI_OVERWRITE_ICON="$PWD/icon.png" # custom icon for notifications (needs absolute path)

--- a/tests/unitTests/borgcron.sh
+++ b/tests/unitTests/borgcron.sh
@@ -96,8 +96,8 @@ testWorks(){
 
 testFails(){
 	# check that it "properly" fails
-	# retry only 2 times
-	addConfigFile "testFails.sh" "REPEAT_NUM=2"
+	# retry only 1 time
+	addConfigFile "testFails.sh" "RETRY_NUM=1"
 
 	doNotCountVersionRequestsInBorg
 	doNotCountLockBreakingsInBorg
@@ -290,7 +290,7 @@ testRetry(){
 
 testNotRetry(){
 	# must not retry
-	addConfigFile "notRetryTest.sh" "REPEAT_NUM=0"
+	addConfigFile "notRetryTest.sh" "RETRY_NUM=0"
 
 	doNotCountVersionRequestsInBorg
 	doNotCountLockBreakingsInBorg

--- a/tests/unitTests/borgcronReal.sh
+++ b/tests/unitTests/borgcronReal.sh
@@ -219,7 +219,7 @@ testBorgEncrypted(){
 	patchConfigDisableVar "exampleTest.sh" 'PRUNE_PARAMS'
 
 	# no retry
-	patchConfigSetVar "exampleTest.sh" 'REPEAT_NUM' '0'
+	patchConfigSetVar "exampleTest.sh" 'RETRY_NUM' '0'
 
 	startTime=$( date +%s )
 	# shellcheck disable=SC2034
@@ -235,7 +235,7 @@ testBorgEncrypted(){
 				"2" \
 				"$exitcode"
 
-	# it fails, but must not retry as REPEAT_NUM is set to 0
+	# it fails, but must not retry as RETRY_NUM is set to 0
 	# shellcheck disable=SC2016
 	assertTrue "borg backup did not retry" \
 				"[ $(( endTime-startTime )) -le 15 ]"


### PR DESCRIPTION
Now really defines the number the backup should **retry** excluding the first try. The previous variable was ambiguous and I think this variable better reflects what it actually does (it retries for _n_ times).