### PR TITLE
Fixing the specialParams to use for regular/internal database dumps

### DIFF
--- a/tools/databasedump.sh
+++ b/tools/databasedump.sh
@@ -17,8 +17,8 @@ for db in $databases; do
 	specialParams="--skip-lock-tables --single-transaction"
 
 	# also dump special internal databases
-	if [ "$db" != "information_schema" ] && [ "$db" != "performance_schema" ] && [ "$db" != "mysql" ] ; then
-		specialParams="--lock-tables --flush-privileges"
+	if [ "$db" = "information_schema" ] || [ "$db" = "performance_schema" ] || [ "$db" = "mysql" ] ; then
+		specialParams="$specialParams --flush-privileges"
 	fi
 
 	echo "Dumping database: $db"


### PR DESCRIPTION
It seems there is a logic flaw in _databasedump.sh_:

- For regular databases _mysqldump_ is called with ```--lock-tables --flush-privileges```.
- With internal databases the options ```--skip-lock-tables --single-transaction``` are used.

Evidently, it should be the other way round because ```--flush-privileges``` is needed especially for those tables that change users and privileges when imported. ```--skip-lock-tables --single-transaction``` should be applied with regular InnoDB databases to ensure data consistency. On MyISAM tables they have no effect though.

However, just flipping logic operators in _databasedump.sh_ would break backups of ```information_schema``` and ```performance_schema``` as MySQL prevents you from setting some tables read only via LOCK TABLES.
The corresponding error message is:
```bash
mysqldump: Got error: 1044: Access denied for user 'root'@'localhost' to database 'information_schema' when using LOCK TABLES"
mysqldump: Got error: 1142: SELECT, LOCK TABLES command denied to user 'root'@'localhost' for table 'accounts' when using LOCK TABLES
```
For the dumps to be created successfully, ```--lock-tables``` has to be left out. This is most probably fine because MyISAM tables in these databases are only rarely written. 