### PR TITLE
Fixes #72

### DIFF
--- a/borgcron.sh
+++ b/borgcron.sh
@@ -256,15 +256,15 @@ getInfoAboutLastBackup() {
 
 # GUI functions (can be overwritten in config file)
 guiCanShowNotifications() {
-		# exclude headless installations from desktop notifications
+	# exclude headless installations from desktop notifications
 	if [ -z "$DISPLAY" ]; then
-    	return 1
-    else
+		return 1
+	else
 		# command to get out, whether we can show notifications
 		# To disable notifications in every case, you can manually set this
 		# to return "false" (or 1, which is shell-speak for false)
-        command -v zenity >/dev/null
-    fi
+		command -v zenity >/dev/null
+	fi
 }
 zenityProxy() {
 	sh -c "zenity $*"

--- a/borgcron.sh
+++ b/borgcron.sh
@@ -256,15 +256,14 @@ getInfoAboutLastBackup() {
 
 # GUI functions (can be overwritten in config file)
 guiCanShowNotifications() {
-	# uses a command to get out, whether we can show notifications
-	# You can manually set this to return "false" (or 1, which is shell-speak for false)
-	# to disable all notifications.
-	currentLoginManager=$(loginctl show-session $XDG_SESSION_ID -p Type)
-	if [ $currentLoginManager = "Type=tty" ]; then
-		return 1
-	else
-		return 0
-	fi
+	if [ -z "$DISPLAY" ]; then
+    	return 1
+    else
+		# command to get out, whether we can show notifications
+		# To disable notifications in every case, you can manually set this
+		# to return "false" (or 1, which is shell-speak for false)
+        command -v zenity >/dev/null
+    fi
 }
 zenityProxy() {
 	sh -c "zenity $*"

--- a/borgcron.sh
+++ b/borgcron.sh
@@ -256,6 +256,7 @@ getInfoAboutLastBackup() {
 
 # GUI functions (can be overwritten in config file)
 guiCanShowNotifications() {
+		# exclude headless installations from desktop notifications
 	if [ -z "$DISPLAY" ]; then
     	return 1
     else

--- a/borgcron.sh
+++ b/borgcron.sh
@@ -258,7 +258,7 @@ getInfoAboutLastBackup() {
 guiCanShowNotifications() {
 	# exclude headless installations from desktop notifications
 	if [ -z "$DISPLAY" ]; then
-		return 1
+		return 1 # (false)
 	else
 		# command to get out, whether we can show notifications
 		# To disable notifications in every case, you can manually set this

--- a/borgcron.sh
+++ b/borgcron.sh
@@ -259,7 +259,12 @@ guiCanShowNotifications() {
 	# uses a command to get out, whether we can show notifications
 	# You can manually set this to return "false" (or 1, which is shell-speak for false)
 	# to disable all notifications.
-	command -v zenity >/dev/null
+	currentLoginManager=$(loginctl show-session $XDG_SESSION_ID -p Type)
+	if [ $currentLoginManager = "Type=tty" ]; then
+		return 1
+	else
+		return 0
+	fi
 }
 zenityProxy() {
 	sh -c "zenity $*"


### PR DESCRIPTION
Solved problem: If used in a headless environment, borgcron shows an error about not being able to access the display, to output the desktop notifications.

**Edit (by @rugk):** Fixes #72