### PR TITLE
bugfix databasedump.sh: create destination folder

### DIFF
--- a/tools/databasedump.sh
+++ b/tools/databasedump.sh
@@ -92,9 +92,9 @@ for db in $DATABASES; do
 	fi
 
 	info_log "MySQL Backup dumping database: \"$db\""
+	mkdir -p "$DESTINATION"
 	# (specialParams intentionally not quoted as it is contains custom directives)
 	# shellcheck disable=SC2086
-	mkdir -p "$DESTINATION"
 	mysqldump -u "$USER" "$PASSWORD" $specialParams --databases "$db" > "$DESTINATION/$db.sql"
 	exitcodeDump=$?
 	track_exitcode $exitcodeDump

--- a/tools/databasedump.sh
+++ b/tools/databasedump.sh
@@ -94,6 +94,7 @@ for db in $DATABASES; do
 	info_log "MySQL Backup dumping database: \"$db\""
 	# (specialParams intentionally not quoted as it is contains custom directives)
 	# shellcheck disable=SC2086
+	mkdir -p "$DESTINATION"
 	mysqldump -u "$USER" "$PASSWORD" $specialParams --databases "$db" > "$DESTINATION/$db.sql"
 	exitcodeDump=$?
 	track_exitcode $exitcodeDump


### PR DESCRIPTION
It's indeed a bug.
I you invoke the `databasedump.sh` with e.g. the current time as the backups destination directory name, you want to let the dump-tool create the folder for you, if nonexistent.

`mkdir -p` could be also invoked before the for-loop, because the "root" destination folder stays the same.
Creating/Checking `mkdir -p` before each backup might be safer, because the directory could be deleted while performing the backups... 
However the decision, the command shouldn't affect performance at all ^^